### PR TITLE
Support for Sparkfun ProMicro board.

### DIFF
--- a/JVSIO.cpp
+++ b/JVSIO.cpp
@@ -14,6 +14,9 @@ constexpr uint8_t kMarker = 0xD0;
 constexpr uint8_t kSync = 0xE0;
 
 void dump(const char* str, uint8_t* data, size_t len) {
+  // TODO : do Serial.begin();
+  // for Arduino series which have native USB CDC (=Serial),
+  //   such as Leonardo, ProMicro, etc. 
   Serial.print(str);
   Serial.print(": ");
   for (size_t i = 0; i < len; ++i) {

--- a/JVSIO.h
+++ b/JVSIO.h
@@ -22,23 +22,23 @@
 //  Sense: See SenseClient implementation
 //  LED Ready: See LedClient implementation
 class JVSIO {
- public:
- class DataClient {
+public:
+  class DataClient {
   public:
-   virtual int available() { return 0; }
-   virtual void setMode(int mode) {}
-   virtual void startTransaction() {}
-   virtual void endTransaction() {}
-   virtual uint8_t read() { return 0; }
-   virtual void write(uint8_t data) {}
- };
+    virtual int available() { return 0; }
+    virtual void setMode(int mode) {}
+    virtual void startTransaction() {}
+    virtual void endTransaction() {}
+    virtual uint8_t read() { return 0; }
+    virtual void write(uint8_t data) {}
+  };
   class SenseClient {
-   public:
+  public:
     virtual void begin() {}
     virtual void set(bool ready) {}
   };
   class LedClient {
-   public:
+  public:
     virtual void begin() {}
     virtual void set(bool ready) {}
   };
@@ -77,7 +77,7 @@ class JVSIO {
 
   void pushReport(uint8_t report);
 
- private:
+private:
   void receive();
 
   void senseNotReady();

--- a/NanoClient.h
+++ b/NanoClient.h
@@ -9,9 +9,11 @@
 
 #include "JVSIO.h"
 
-// Data+: 0 (RXI)
-// Data-: 2
+// Data+: 0 (RXI) (PD0)
+// Data-: 2       (PD2)
 class NanoDataClient : public JVSIO::DataClient {
+  const int portNumPlus = 0;
+  const int portNumMinus = 2;
   int available() override;
   void setMode(int mode) override;
   void startTransaction() override;
@@ -20,15 +22,16 @@ class NanoDataClient : public JVSIO::DataClient {
   void write(uint8_t data)override;
 };
  
-// Sense: 3 (PWM - RC LPF of 100nF, 100Ω is needed to generate 2.5V)
+// Sense: 3 (PWM OC2B - RC LPF of 100nF, 100Ω is needed to generate 2.5V)
 class NanoSenseClient : public JVSIO::SenseClient {
- public:
+  const int portNum = 3;
   void begin() override;
   void set(bool ready) override;
 };
 
 // LED Ready: 13
 class NanoLedClient : public JVSIO::LedClient {
+  const int portNum = 13;
   void begin() override;
   void set(bool ready) override;
 };

--- a/ProMicroClient.h
+++ b/ProMicroClient.h
@@ -1,0 +1,35 @@
+#include <stdint.h>
+
+#if !defined(__ProMicroClient_H__)
+#define __ProMicroClient_H__
+
+#include "JVSIO.h"
+
+// Data+: 0 (RXI) (PD2)
+// Data-: 2       (PD1)
+class ProMicroDataClient : public JVSIO::DataClient {
+  const int portNumPlus    = 0;
+  const int portNumMinus   = 2;
+  int available() override;
+  void setMode(int mode) override;
+  void startTransaction() override;
+  void endTransaction() override;
+  uint8_t read() override;
+  void write(uint8_t data)override;
+};
+ 
+// Sense: 9 (PWM OC1A - RC LPF of 100nF, 100Ω is needed to generate 2.5V)
+class ProMicroSenseClient : public JVSIO::SenseClient {
+  const int portNum = 9;
+  void begin() override;
+  void set(bool ready) override;
+};
+
+// LED Ready: 21 (note : ProMicro don't have onboard LED)
+class ProMicroLedClient : public JVSIO::LedClient {
+  const int portNum = 21;
+  void begin() override;
+  void set(bool ready) override;
+};
+
+#endif  // !defined(__ProMicroClient_H__)


### PR DESCRIPTION
- add ProMicroClient.cpp and .h
- replace port number to const variable
- replace assembler port address and bit into input operands
  - I wanted to do with const variable,
    but it failed so put immediate directly.
- fix NanoSenseClient::set's value (0x30->0x10)
- add some comments
- adding USB CDC Initialize (Serial.begin()) needed  with dump(), but not implemented yet